### PR TITLE
fix(deps): rustls-webpki 0.103.10 → 0.103.13 (RUSTSEC-2026-0097/0099)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4042,9 +4042,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Bumps `rustls-webpki` to a patched version that addresses two open RustSec advisories affecting our transitive deps (via `rustls v0.23.38`).
- Unblocks `cargo-deny` CI on `main` and every open Dependabot PR (all failing the same advisory check since 2026-04-13).
- Closes Dependabot alerts #70 and #71.

## Advisories fixed
- **RUSTSEC-2026-0099** (GHSA-xgp8-3hg3-c2mh) — name constraints accepted for certificates asserting a wildcard name.
- **RUSTSEC-2026-0097** (GHSA-965h-392x-2mh5) — name constraints for URI names incorrectly accepted.

## Test plan
- [x] `cargo check --workspace --locked` — clean.
- [x] `cargo deny --locked check advisories` — `advisories ok` locally.
- [ ] CI: cargo-deny policy checks green.
- [ ] CI: full workspace tests green.