### PR TITLE
docs(mcp): document 2026 guardrails

### DIFF
--- a/docs/ACIS_CONTRACT.md
+++ b/docs/ACIS_CONTRACT.md
@@ -28,7 +28,7 @@ Source: `vellaveto-types/src/acis.rs`
 |-------|------|----------|-------------|
 | `decision_id` | `String` | yes | UUID v4 hex, max 64 chars |
 | `timestamp` | `String` | yes | RFC 3339, must end with `Z` or `+00:00` |
-| `session_id` | `Option<String>` | no | From `Mcp-Session-Id` header or stateless blob, max 512 |
+| `session_id` | `Option<String>` | no | Transport-scoped isolation identifier: stdio relay UUID, WebSocket connection UUID, HTTP proxy session state, or legacy `Mcp-Session-Id` when present; max 512 |
 | `tenant_id` | `Option<String>` | no | Multi-tenant identifier, max 256 |
 | `agent_identity` | `Option<AgentIdentity>` | no | Cryptographically attested identity from JWT |
 | `agent_id` | `Option<String>` | no | Legacy agent identifier, max 512 |

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -52,15 +52,15 @@ For load testing under concurrency, see [perf/LOADTEST.md](../perf/LOADTEST.md).
 | **Test evidence** | `vellaveto-audit/src/tests.rs` — hash chain verification, corruption detection, checkpoint validation, Merkle proof verification; `vellaveto-integration/tests/` — audit integrity tests |
 | **Reproduce** | `cargo test -p vellaveto-audit -- chain && cargo test -p vellaveto-audit -- checkpoint && cargo test -p vellaveto-audit -- merkle` |
 
-### C4. "MCP 2025-11-25 compliance with backwards compatibility"
+### C4. "MCP 2025-11-25 and 2026-07-28 compliance with version-gated compatibility"
 
 | Field | Value |
 |-------|-------|
-| **Scope** | JSON-RPC 2.0 message handling, MCP method routing, capability negotiation, elicitation/sampling interception |
+| **Scope** | JSON-RPC 2.0 message handling, MCP method routing, protocol-version dispatch, capability negotiation, elicitation/sampling interception |
 | **Assumptions** | Upstream MCP server is spec-compliant |
-| **Test evidence** | `vellaveto-mcp/src/tests.rs` — protocol conformance tests; `vellaveto-integration/tests/` — transport-specific tests for HTTP, stdio, WebSocket, gRPC |
-| **Backwards compat** | Tested against 2025-03-26 and 2025-06-18 message formats |
-| **Reproduce** | `cargo test -p vellaveto-mcp -- protocol && cargo test -p vellaveto-integration` |
+| **Test evidence** | `vellaveto-mcp/src/wire.rs` adapter and `_meta` normalization tests; `vellaveto-http-proxy/tests/proxy_integration.rs` HTTP routing, `requestState`, SSE, and WebSocket guardrails; `vellaveto-integration/tests/` transport/version compatibility |
+| **Backwards compat** | Default advertised floor is `2025-11-25`, with `2026-07-28` preferred. Older known versions remain parseable only when policy explicitly lowers the floor. |
+| **Reproduce** | `cargo test -p vellaveto-mcp wire && cargo test -p vellaveto-http-proxy request_state && cargo test -p vellaveto-http-proxy server_request && cargo test -p vellaveto-integration` |
 
 ### C5. "EU AI Act compliance (Art 50(2) + Art 10)"
 

--- a/docs/BOUNDARY_INVENTORY.md
+++ b/docs/BOUNDARY_INVENTORY.md
@@ -40,7 +40,9 @@ via `RelayState.agent_id`.
 | `handle_mcp_get()` | `GET /mcp/*` | `fingerprint_action` | RequireApproval gate | Y | Y | Y | `log_entry_with_acis` |
 | `handle_protected_resource_metadata()` | `GET /api/resource-metadata` | — | — | N | N | N | Y |
 
-**Session identity:** `Mcp-Session-Id` header, OAuth claims for `requested_by`.
+**Session identity:** HTTP proxy session state, OAuth/API-key principal, and
+legacy `Mcp-Session-Id` when present. MCP `2026-07-28` peers are treated as
+stateless per request; protocol session headers are not assumed.
 
 ### HTTP Sub-interceptors
 
@@ -50,6 +52,8 @@ via `RelayState.agent_id`.
 | `auth.rs` | Auth validation | OAuth/API-key enforcement | `log_entry_with_acis` |
 | `upstream.rs` | Upstream forwarding | Response DLP + injection | `log_entry_with_acis` |
 | `helpers.rs` | Approval gate | Approval creation/consumption | `log_entry_with_acis` |
+| `request_state.rs` | Continuation sealing | HMAC-sealed `requestState`, replay/expiry denial | `log_entry_with_acis` |
+| `server_request.rs` | Server-request control | Deny detached server-initiated JSON-RPC requests | `log_entry_with_acis` |
 
 ---
 

--- a/docs/DEFAULTS.md
+++ b/docs/DEFAULTS.md
@@ -62,6 +62,16 @@ explicit opt-in. Silent insecurity is a bug.
 | `max_validation_depth` | **20** | JSON nesting depth limit. Prevents stack exhaustion. |
 | `max_path_decode_iterations` | **3** | Limits percent-decode/base64-decode passes. Prevents DoS via deeply nested encoding. |
 
+## MCP Streamable HTTP
+
+| Setting | Default | Rationale |
+|---------|---------|-----------|
+| `streamable_http.protocol_version_floor` | **`2025-11-25`** | Keeps the current migration window while refusing older protocol behavior unless policy explicitly lowers the floor. |
+| `streamable_http.require_protocol_version_header` | **`true`** | Firewalls must not guess MCP wire semantics from a missing header. |
+| `streamable_http.allowed_mcp_param_headers` | **Empty** | Custom `Mcp-Param-*` headers are denied until the operator allowlists each suffix. |
+| `streamable_http.resumability_enabled` | **`false`** | Detached GET SSE resumability is opt-in. |
+| `streamable_http.max_event_id_length` | **128 bytes** | Caps `Last-Event-ID` and SSE event identifier memory exposure. |
+
 ## Config Loading
 
 | Setting | Default | Rationale |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -78,6 +78,25 @@ admin = 0     # Disabled
 - **Resource Indicators:** OAuth RFC 8707 support
 - **Step-Up Authentication:** Configurable auth level requirements
 
+### MCP 2026-07-28 Guardrails
+
+- **Version-gated dispatch:** HTTP MCP requests must declare
+  `MCP-Protocol-Version` by default. `streamable_http.protocol_version_floor`
+  rejects versions below the configured floor.
+- **Canonical wire model:** MCP `2025-11-25` and `2026-07-28` messages are
+  normalized before policy and audit code sees them.
+- **Routing header agreement:** `Mcp-Method` and `Mcp-Name` must match the
+  JSON-RPC body for `2026-07-28` traffic.
+- **`Mcp-Param-*` allowlisting:** Custom parameter-derived headers require both
+  an operator allowlist entry and an observed tool-schema `x-mcp-header`
+  declaration.
+- **`requestState` sealing:** Multi-round-trip continuations are wrapped in
+  Vellaveto tokens and denied on tamper, replay, expiry, or missing session
+  state.
+- **Server-request control:** Detached GET SSE server requests are denied, and
+  WebSocket server requests require a live client request in the same
+  connection.
+
 ### Phase 2: Advanced Threat Detection
 
 - **Circuit Breaker:** Cascading failure protection
@@ -258,6 +277,18 @@ similarity_threshold = 0.9
 [sampling_detection]
 enabled = false
 max_requests_per_session = 100
+
+# ═══════════════════════════════════════════════════════════════
+# MCP Streamable HTTP Protocol Guardrails
+# ═══════════════════════════════════════════════════════════════
+
+[streamable_http]
+resumability_enabled = true
+strict_tool_name_validation = false
+max_event_id_length = 128
+protocol_version_floor = "2025-11-25"
+require_protocol_version_header = true
+allowed_mcp_param_headers = []
 
 # ═══════════════════════════════════════════════════════════════
 # Phase 3: Cross-Agent Security (Optional)

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -136,7 +136,23 @@ vellaveto policies --preset deny-all    # Deny everything by default
 vellaveto policies --preset allow-all   # Allow everything (testing only)
 ```
 
-See [`examples/presets/`](../examples/presets/) for additional preset templates including consumer shield, MCP 2025-11-25, production, and SANDWORM hardening configurations.
+See [`examples/presets/`](../examples/presets/) for additional preset templates including consumer shield, MCP protocol, production, and SANDWORM hardening configurations.
+
+## MCP Streamable HTTP
+
+Control MCP HTTP compatibility and fail-closed protocol checks:
+
+```toml
+[streamable_http]
+protocol_version_floor = "2025-11-25"  # Accept 2025-11-25 and newer
+require_protocol_version_header = true # Deny requests missing MCP-Protocol-Version
+resumability_enabled = true            # Enable GET /mcp SSE resumption
+allowed_mcp_param_headers = []         # Deny Mcp-Param-* unless allowlisted
+```
+
+`allowed_mcp_param_headers` controls custom headers derived from tool
+parameters. A header is forwarded only when the suffix is allowlisted here and
+the observed tool schema declares the same `x-mcp-header` binding.
 
 ## Elicitation & Sampling Policies
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -475,6 +475,11 @@ vellaveto-http-proxy \
 
 Your agent connects to `localhost:3000` instead of the upstream server directly. Vellaveto inspects every request and response.
 
+HTTP MCP clients should send `MCP-Protocol-Version`. The default proxy policy
+accepts `2025-11-25` and `2026-07-28` and denies missing or older versions.
+When using `2026-07-28`, `Mcp-Method` and `Mcp-Name` headers must agree with
+the JSON-RPC body.
+
 ---
 
 ## Parameter Redaction

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -22,6 +22,7 @@ This guide covers security best practices and hardening configurations for produ
   - [Injection Scanning](#injection-scanning)
   - [DLP Configuration](#dlp-configuration)
   - [Rug-Pull Detection](#rug-pull-detection)
+  - [MCP Protocol Guardrails](#mcp-protocol-guardrails)
   - [Behavioral Anomaly Detection](#behavioral-anomaly-detection)
 - [Audit & Compliance](#audit--compliance)
   - [Audit Log Configuration](#audit-log-configuration)
@@ -541,6 +542,35 @@ manifest_path = "/etc/vellaveto/manifest.json"
 ```
 
 On first run, Vellaveto captures tool schemas. On subsequent runs, any schema changes trigger alerts or blocks.
+
+### MCP Protocol Guardrails
+
+For HTTP and WebSocket MCP traffic, Vellaveto enforces protocol checks before
+forwarding to the upstream server:
+
+- Unknown MCP protocol versions are denied. HTTP requests must include
+  `MCP-Protocol-Version` unless `require_protocol_version_header` is explicitly
+  disabled.
+- `streamable_http.protocol_version_floor` defaults to `2025-11-25`. Lower
+  versions are not advertised or accepted at the default floor.
+- `Mcp-Method` and `Mcp-Name` routing headers must agree with the JSON-RPC
+  body on `2026-07-28` traffic.
+- `Mcp-Param-*` headers are denied unless the suffix is operator-allowlisted
+  and the current tool definition declared the same `x-mcp-header` binding.
+- Upstream `requestState` values are sealed before the client sees them.
+  Continuations are accepted once, in the same session, before expiry.
+- Detached server-initiated requests on GET SSE are denied. WebSocket
+  server-initiated requests are only forwarded while a client request is live
+  on that connection.
+
+Recommended baseline:
+
+```toml
+[streamable_http]
+protocol_version_floor = "2025-11-25"
+require_protocol_version_header = true
+allowed_mcp_param_headers = []
+```
 
 ### Behavioral Anomaly Detection
 

--- a/examples/mcp-2025-11-25.toml
+++ b/examples/mcp-2025-11-25.toml
@@ -1,24 +1,29 @@
-# MCP 2025-11-25 Compliance Configuration
+# MCP 2025-11-25 / 2026-07-28 Compatibility Configuration
 #
-# This example demonstrates the new security features introduced in
-# MCP 2025-11-25, including Streamable HTTP (SSE resumability, strict
-# tool name validation), async task policies, resource indicators,
-# capability-based routing (CIMD), and step-up authentication.
+# This example demonstrates MCP 2025-11-25 security features plus the
+# 2026-07-28 migration guardrails: protocol-version floors, required routing
+# headers, x-mcp-header allowlisting, requestState sealing, and detached
+# server-request rejection.
 
 # ═══════════════════════════════════════════════════════════════════
-# STREAMABLE HTTP CONFIGURATION (Phase 30)
+# STREAMABLE HTTP CONFIGURATION
 # ═══════════════════════════════════════════════════════════════════
 #
-# Controls MCP 2025-11-25 Streamable HTTP features:
+# Controls MCP Streamable HTTP features:
 # - SSE resumability via GET /mcp with Last-Event-ID
 # - Strict tool name validation per spec format
 # - Event ID length limits for memory safety
 # - SSE retry directive overrides
+# - Protocol version floor and required version header
+# - Allowlist for parameter-derived Mcp-Param-* headers
 
 [streamable_http]
 resumability_enabled = true             # Enable GET /mcp for SSE resumption
 strict_tool_name_validation = false     # Opt-in: reject non-spec tool names
 max_event_id_length = 128               # Max bytes for Last-Event-ID (1-512)
+protocol_version_floor = "2025-11-25"   # Accept 2025-11-25 and newer
+require_protocol_version_header = true  # Deny missing MCP-Protocol-Version
+allowed_mcp_param_headers = []          # Add x-mcp-header suffixes explicitly
 # sse_retry_ms = 3000                   # Override SSE retry directive (100-60000)
 
 # ═══════════════════════════════════════════════════════════════════

--- a/vellaveto-config/README.md
+++ b/vellaveto-config/README.md
@@ -9,6 +9,7 @@ Parses TOML policy files into validated `PolicyConfig` structs with:
 - Path rules, network rules, ABAC constraints
 - Discovery, topology, and shield configuration
 - Cedar policy import/export for AWS AgentCore interoperability
+- MCP Streamable HTTP protocol-version floors and routing header allowlists
 - Bounded validation on all fields (max lengths, collection sizes, numeric ranges)
 - `deny_unknown_fields` on all deserialized structs
 
@@ -19,8 +20,27 @@ Parses TOML policy files into validated `PolicyConfig` structs with:
 vellaveto-config = "6"
 ```
 
+## Streamable HTTP Settings
+
+The `streamable_http` section controls MCP Streamable HTTP compatibility and
+fail-closed protocol checks:
+
+```toml
+[streamable_http]
+protocol_version_floor = "2025-11-25"
+require_protocol_version_header = true
+resumability_enabled = true
+max_event_id_length = 128
+allowed_mcp_param_headers = ["Region", "TenantId"]
+```
+
+`protocol_version_floor` rejects inbound versions below the configured floor.
+`allowed_mcp_param_headers` lists permitted `Mcp-Param-*` suffixes; every entry
+must be a valid HTTP field-name token, cannot be duplicated
+case-insensitively, and is capped by the config validator.
+
 ## License
 
-MPL-2.0 — see [LICENSE-MPL-2.0](../LICENSE-MPL-2.0) in the repository root.
+MPL-2.0 - see [LICENSE-MPL-2.0](../LICENSE-MPL-2.0) in the repository root.
 
 Part of the [Vellaveto](https://github.com/paolovella/vellaveto) project.

--- a/vellaveto-http-proxy/README.md
+++ b/vellaveto-http-proxy/README.md
@@ -6,11 +6,13 @@ Streamable HTTP reverse proxy for the [Vellaveto](https://vellaveto.online) MCP 
 
 Inline policy enforcement across multiple transport protocols:
 
-- **HTTP reverse proxy** — intercepts MCP tool calls over Streamable HTTP
-- **WebSocket proxy** — bidirectional MCP message inspection
-- **gRPC proxy** — protocol-aware tool call interception
-- **Transport health** — automatic health checking with smart fallback
-- **OAuth 2.1** — JWT/JWKS validation with DPoP binding
+- **HTTP reverse proxy** - intercepts MCP tool calls over Streamable HTTP
+- **WebSocket proxy** - bidirectional MCP message inspection
+- **gRPC proxy** - protocol-aware tool call interception
+- **Transport health** - automatic health checking with smart fallback
+- **OAuth 2.1** - JWT/JWKS validation with DPoP binding
+- **MCP 2026 guardrails** - version-gated routing headers, `requestState`
+  sealing, and unsolicited server-request blocking
 
 ## Usage
 
@@ -19,8 +21,38 @@ Inline policy enforcement across multiple transport protocols:
 vellaveto-http-proxy = "6"
 ```
 
+## MCP Protocol Guardrails
+
+The proxy accepts MCP protocol versions through a configurable floor. By
+default, inbound HTTP requests must include `MCP-Protocol-Version`, and the
+default floor is `2025-11-25`. The proxy advertises and forwards
+`2026-07-28` to upstream servers.
+
+```toml
+[streamable_http]
+protocol_version_floor = "2025-11-25"
+require_protocol_version_header = true
+resumability_enabled = true
+allowed_mcp_param_headers = ["Region", "TenantId"]
+```
+
+For `2026-07-28` requests, `Mcp-Method` and `Mcp-Name` routing headers must
+agree with the JSON-RPC body. Custom `Mcp-Param-*` headers are only forwarded
+when both policy allowlists the suffix and the observed `tools/list` schema
+declares the matching `x-mcp-header` binding. Reserved headers such as
+`Authorization`, `Host`, and `Cookie` are never sourced from tool parameters.
+
+Multi-round-trip `requestState` values from upstream responses are replaced
+with Vellaveto-sealed tokens before they reach the client. A later client echo
+must present the sealed token in the same session; tampered, expired, replayed,
+or untracked tokens are denied.
+
+Detached server-initiated JSON-RPC requests are fail-closed. `GET /mcp` SSE
+streams cannot carry server requests, and WebSocket upstream requests are only
+forwarded while a client request is live in the same connection.
+
 ## License
 
-BUSL-1.1 — see [LICENSE-BSL-1.1](../LICENSE-BSL-1.1) and [LICENSING.md](../LICENSING.md) in the repository root.
+BUSL-1.1 - see [LICENSE-BSL-1.1](../LICENSE-BSL-1.1) and [LICENSING.md](../LICENSING.md) in the repository root.
 
 Part of the [Vellaveto](https://github.com/paolovella/vellaveto) project.

--- a/vellaveto-mcp/README.md
+++ b/vellaveto-mcp/README.md
@@ -6,13 +6,16 @@ MCP protocol security layer for the [Vellaveto](https://vellaveto.online) gatewa
 
 Handles MCP-specific security concerns between agents and their tools:
 
-- **DLP inspection** — 5-layer decode pipeline with Aho-Corasick pattern matching
-- **Injection detection** — NFKC normalization, ROT13/base64/leetspeak decode, Policy Puppetry defense
-- **Tool registry** — topology-aware tool verification with Levenshtein suggestions
-- **Semantic guardrails** — output schema validation and behavioral constraints
-- **Multimodal inspection** — image and document content scanning
-- **A2A hardening** — Agent Card signature enforcement, DPoP token binding
-- **MCP 2025-11-25 compliant** — Tasks, CIMD, XAA, M2M auth, step-up authorization
+- **DLP inspection** - 5-layer decode pipeline with Aho-Corasick pattern matching
+- **Injection detection** - NFKC normalization, ROT13/base64/leetspeak decode, Policy Puppetry defense
+- **Tool registry** - topology-aware tool verification with Levenshtein suggestions
+- **Semantic guardrails** - output schema validation and behavioral constraints
+- **Multimodal inspection** - image and document content scanning
+- **A2A hardening** - Agent Card signature enforcement, DPoP token binding
+- **MCP 2025-11-25 / 2026-07-28 adapters** - version-gated wire
+  normalization into canonical policy and audit requests
+- **Typed `_meta` ingestion** - bounded trace context parsing, protocol-version
+  agreement checks, and quarantine for unknown metadata keys
 
 ## Usage
 
@@ -21,8 +24,28 @@ Handles MCP-specific security concerns between agents and their tools:
 vellaveto-mcp = "6"
 ```
 
+## Wire Normalization
+
+`vellaveto-mcp::wire` is the adapter boundary between MCP JSON-RPC wire
+messages and Vellaveto's transport-independent policy model. Supported
+versions are parsed as ordered `McpProtocolVersion` values, with `2026-07-28`
+preferred and `2025-11-25` retained for the migration window.
+
+The adapter normalizes inbound messages into `CanonicalRequest` values with:
+
+- method and optional name
+- message kind: request, notification, or response
+- validated protocol version
+- bounded typed `_meta`
+- sanitized trace correlation
+- normalized JSON arguments
+
+Malformed `_meta`, conflicting top-level and `params._meta`, protocol-version
+mismatch, malformed `traceparent`, oversized metadata, and JSON-RPC batch
+messages return an adapter denial instead of passing through silently.
+
 ## License
 
-BUSL-1.1 — see [LICENSE-BSL-1.1](../LICENSE-BSL-1.1) and [LICENSING.md](../LICENSING.md) in the repository root.
+BUSL-1.1 - see [LICENSE-BSL-1.1](../LICENSE-BSL-1.1) and [LICENSING.md](../LICENSING.md) in the repository root.
 
 Part of the [Vellaveto](https://github.com/paolovella/vellaveto) project.


### PR DESCRIPTION
Update operator and module docs for MCP 2026-07-28 protocol handling, including version floors, routing header validation, requestState sealing, and server-request blocking.

Refresh the MCP compatibility example with the new Streamable HTTP settings.

## Summary

<!-- Brief description of changes (1-3 sentences) -->

## Changes

<!-- Bulleted list of what changed -->

-

## Testing

<!-- How did you verify these changes? -->

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace` clean
- [ ] `cargo fmt --check` passes
- [ ] New tests added for new functionality
- [ ] No `unwrap()` or `expect()` in library code

## Checklist

- [ ] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Fail-closed: errors produce `Deny`, not `Allow`
- [ ] No secrets in code or test fixtures
- [ ] Crate dependency graph not violated
- [ ] CHANGELOG.md updated (if user-facing)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->
