### PR TITLE
deps(cargo): bump cmov and serde_with (supersedes #249, #265)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "color_quant"
@@ -4563,9 +4563,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -398,7 +398,7 @@ version = "0.1.58"
 criteria = "safe-to-deploy"
 
 [[exemptions.cmov]]
-version = "0.5.3"
+version = "0.5.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.color_quant]]
@@ -1786,7 +1786,7 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_with]]
-version = "3.20.0"
+version = "3.21.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_yaml]]


### PR DESCRIPTION
Combines the two open dependabot cargo bumps into a single branch so the
cargo-vet exemptions can be updated alongside `Cargo.lock`.

- `cmov` 0.5.3 -> 0.5.4
- `serde_with` 3.20.0 -> 3.21.0

Dependabot cannot edit `supply-chain/config.toml`, so each of its cargo PRs
fails the **Supply Chain Audit (cargo-vet)** gate on its own. This branch bumps
the lockfile and the matching exemption entries together.

Lockfile verified consistent with `cargo metadata --locked`.

Supersedes #249 and #265 — close both once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)