### PR TITLE
deps(admin-console): migrate react-router 7 -> 8 to clear 5 advisories

### DIFF
--- a/admin-console/package-lock.json
+++ b/admin-console/package-lock.json
@@ -16,7 +16,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-oidc-context": "^3.3.1",
-        "react-router-dom": "^7.17.0",
+        "react-router": "^8.3.0",
         "recharts": "^3.8.1"
       },
       "devDependencies": {
@@ -26,7 +26,6 @@
         "@types/node": "^25.9.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^6.0.2",
         "eslint": "^10.4.1",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -1332,13 +1331,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/history": {
-      "version": "4.7.11",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1374,29 +1366,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
-      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@types/use-sync-external-store": {
@@ -1994,18 +1963,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3560,41 +3522,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.17.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/recharts": {
@@ -3734,12 +3679,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/admin-console/package.json
+++ b/admin-console/package.json
@@ -20,7 +20,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-oidc-context": "^3.3.1",
-    "react-router-dom": "^7.17.0",
+    "react-router": "^8.3.0",
     "recharts": "^3.8.1"
   },
   "devDependencies": {
@@ -30,7 +30,6 @@
     "@types/node": "^25.9.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^6.0.2",
     "eslint": "^10.4.1",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Paolo Vella
 // SPDX-License-Identifier: BUSL-1.1
 
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "./auth/AuthProvider";
 import { useAuth } from "./auth/authContext";

--- a/admin-console/src/components/layout/Layout.tsx
+++ b/admin-console/src/components/layout/Layout.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Paolo Vella
 // SPDX-License-Identifier: BUSL-1.1
 
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { Sidebar } from "./Sidebar";
 import { Header } from "./Header";
 

--- a/admin-console/src/components/layout/Sidebar.tsx
+++ b/admin-console/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Paolo Vella
 // SPDX-License-Identifier: BUSL-1.1
 
-import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router";
 import {
   LayoutDashboard,
   ScrollText,

--- a/admin-console/src/test/wrapper.tsx
+++ b/admin-console/src/test/wrapper.tsx
@@ -5,7 +5,7 @@
  * Test wrapper providing QueryClient + Router + Auth context.
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import type { ReactNode } from "react";
 
 export function createWrapper(initialRoute = "/") {


### PR DESCRIPTION
Clears **all five** open react-router alerts in `admin-console` (2 high, 3 moderate), including `GHSA-qwww-vcr4-c8h2` (RSC Mode CSRF Bypass).

### Why a major bump is required

`8.3.0` is the first version outside the vulnerable range `>=7.12.0 <8.3.0`. A lockfile-only fix cannot reach it — #285 (`9bdbe178`) recorded that `npm audit fix` moved react-router to `7.18.1`, still inside the range, and Dependency Review correctly rejected it.

### The only real breaking change

`react-router-dom` has **no v8 line** (it stops at 7.18.2) and is discontinued; imports move to `react-router` directly.

admin-console uses only seven core declarative symbols — `BrowserRouter`, `MemoryRouter`, `Routes`, `Route`, `Outlet`, `Navigate`, `NavLink` — and **none** of the data-router APIs (loaders, actions, `RouterProvider`, `useFetcher`) where 7→8 breakage concentrates. So all four import sites are mechanical one-liners.

```
 admin-console/package-lock.json  | 87 +++-------------------
 admin-console/package.json       |  3 +-
 admin-console/src/App.tsx        |  2 +-
 .../src/components/layout/Layout.tsx  |  2 +-
 .../src/components/layout/Sidebar.tsx |  2 +-
 admin-console/src/test/wrapper.tsx    |  2 +-
 6 files changed, 18 insertions(+), 80 deletions(-)
```

Also drops `@types/react-router-dom@5.3.3` — v5 types against a v7 runtime, obsolete since react-router ships its own.

### Node engine

`react-router@8.3.0` declares `engines: node >=22.22.0`. `surface-ci.yml` pins `node-version: 22` (floating latest), which satisfies it. Developers on an older 22.x will see a non-fatal `EBADENGINE` warning.

### Verification

- `tsc -b && vite build` — ok, 1867 modules transformed
- `vitest run` — **59/59 passed**, 6 files
- `eslint .` — clean
- `npm audit` — **0 vulnerabilities**