### PR TITLE
ci(dependabot): hold typescript majors where typescript-eslint blocks them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,15 @@ updates:
       admin-console:
         patterns:
           - "*"
+    ignore:
+      # typescript-eslint 8.x declares a peer of typescript ">=4.8.4 <6.1.0",
+      # and no stable typescript-eslint supports typescript 7 yet (only
+      # 8.65.1-alpha.*). Grouping a typescript 7 major into this directory makes
+      # the whole group unmergeable on npm peer resolution -- that is what closed
+      # #293. Minor and patch updates inside typescript 6.x still flow.
+      # Remove this once typescript-eslint ships a stable release admitting 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 5
     commit-message:
       prefix: "deps(admin-console)"
@@ -67,6 +76,14 @@ updates:
       typescript-sdk:
         patterns:
           - "*"
+    ignore:
+      # Same peer conflict as /admin-console: typescript-eslint 8.x pins
+      # typescript ">=4.8.4 <6.1.0", so a typescript 7 major in this group fails
+      # npm resolution on Node 18, 20 and 22 -- that is what closed #277.
+      # Minor and patch updates inside typescript 6.x still flow.
+      # Remove this once typescript-eslint ships a stable release admitting 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 5
     commit-message:
       prefix: "deps(sdk-typescript)"


### PR DESCRIPTION
Stops dependabot regenerating an unmergeable group every week.

### The conflict

`typescript-eslint@8.x` declares a peer of `typescript ">=4.8.4 <6.1.0"`, and **no stable `typescript-eslint` supports typescript 7** — only `8.65.1-alpha.*` exists. When dependabot bundles a typescript 7 major into a directory that also uses typescript-eslint, npm peer resolution fails and the whole group becomes unmergeable, taking otherwise-good security bumps down with it.

That happened twice:

| PR | Directory | Carried | Outcome |
|---|---|---|---|
| #293 | `/admin-console` | react-router advisories | blocked on peer conflict, closed |
| #277 | `/sdk/typescript` | brace-expansion advisories | failed Node 18/20/22, closed |

Both had their security content landed separately — #298 and #297 — but dependabot regenerates the group weekly, so the same unmergeable PR keeps coming back.

### Scope

Deliberately limited to the two directories that actually declare typescript-eslint:

- `/admin-console` — `typescript-eslint ^8.60.1`
- `/sdk/typescript` — `typescript-eslint ^8.60.0`

The other three directories declaring typescript (`packages/create-vellaveto`, `packages/vellaveto-desktop`, `vscode-vellaveto`) have **no** typescript-eslint and therefore no conflict — they are left alone rather than blanket-ignored.

### Not a blanket block

Restricted to `version-update:semver-major`, so minor and patch updates inside typescript 6.x continue to flow. Only the 7 major is held.

Both entries carry a comment naming the removal condition: a stable `typescript-eslint` release whose peer range admits typescript 7.