### PR TITLE
deps(auth): migrate jsonwebtoken 10.4 -> 11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,9 +2600,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1062,7 +1062,7 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonwebtoken]]
-version = "10.4.0"
+version = "11.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.k8s-openapi]]

--- a/vellaveto-http-proxy/Cargo.toml
+++ b/vellaveto-http-proxy/Cargo.toml
@@ -49,7 +49,7 @@ ed25519-dalek = { workspace = true }
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4.6", features = ["derive"] }
 dashmap = "6"
-jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "11", features = ["aws_lc_rs", "use_pem"] }
 reqwest = { workspace = true, features = ["stream"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/vellaveto-server/Cargo.toml
+++ b/vellaveto-server/Cargo.toml
@@ -60,7 +60,7 @@ tower = "0.5"
 governor = "0.10"
 subtle = "2"
 uuid = { workspace = true }
-jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "11", features = ["aws_lc_rs", "use_pem"] }
 ed25519-dalek = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }


### PR DESCRIPTION
Second of the crypto major bumps bundled into #306, taken on its own so the JWT verification path is reviewed independently.

### The migration needs exactly one substantive change

`use_pem` must now be requested explicitly. jsonwebtoken 10.4 declared `default = [use_pem]`; **11.0's default feature set is empty** — the changelog entry is *"BREAKING: Implicit features resulting from optional crates have been removed."*

Without it, PEM key loading disappears — and that is **production code**, not test scaffolding:

| site | API |
|---|---|
| `vellaveto-server/src/rbac.rs:555` | `DecodingKey::from_rsa_pem` |
| `vellaveto-server/src/rbac.rs:557` | `DecodingKey::from_ec_pem` |
| `vellaveto-server/src/rbac.rs:559` | `DecodingKey::from_ed_pem` |

Those back JWT verification for RSA, EC and EdDSA public keys. Both manifests now request `features = ["aws_lc_rs", "use_pem"]`.

### No source changes required

The APIs 11.0 removed are all unused here — verified by grep, not inferred from a clean build:

- `insecure_disable_signature_validation` (removed; use `dangerous::insecure_decode`)
- `try_get_hmac_secret` (removed from both key types)
- `EncodingKey.inner` (renamed to `as_bytes`)

**Validation semantics are unchanged.** `set_issuer`, `set_audience`, `validate_exp`, `validate_nbf` and `leeway` all survive; the call sites in `rbac.rs` and `oauth.rs` are untouched.

### Interaction with #313 (ed25519-dalek 3.0), currently open

jsonwebtoken 11 **drops its `signature` dependency entirely** — with the `aws_lc_rs` backend and implicit optional features removed, it no longer pulls the rust_crypto stack.

#313 adds a duplicate-baseline entry for `signature` 2.2.0/3.0.0 on the assumption jsonwebtoken keeps pinning signature 2. **Once both land, `signature` 3.0 is the only version and that baseline entry becomes stale** — it must be removed, or it silently permits a duplicate that no longer exists.

### MSRV

jsonwebtoken 11.0 requires `rust-version 1.88.0`, exactly the repository MSRV. No headroom, but no violation.

### Verification

| gate | result |
|---|---|
| `cargo check --workspace --all-targets --locked` | 0 errors |
| `cargo clippy` (CI-exact flags) | 0 warnings |
| `scripts/check-cargo-duplicates.sh` | OK, 29 names (unchanged) |
| `cargo vet --locked` | Vetting Succeeded (628 exempted) |
| `cargo deny check` | advisories / bans / licenses / sources ok |
| `cargo test --workspace --no-fail-fast` | **11,650 passed, 0 failed**, 26 ignored |
| all six feature combos CI exercises | zk-audit, discovery, projector, a2a, redis-backend, all-features — all OK |

cargo-vet exemptions regenerated in the same commit.