### PR TITLE
deps(crypto): migrate chacha20poly1305 0.10 -> 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,12 +10,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -768,37 +768,26 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
+ "cipher",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
  "aead",
- "chacha20 0.9.1",
+ "chacha20",
  "cipher",
  "poly1305",
- "zeroize",
 ]
 
 [[package]]
@@ -844,13 +833,13 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.7",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
- "zeroize",
 ]
 
 [[package]]
@@ -1104,7 +1093,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1114,7 +1102,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2414,11 +2404,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3193,12 +3183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3545,12 +3529,11 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -3851,7 +3834,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -5619,12 +5602,12 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -66,7 +66,7 @@ version = "2.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.aead]]
-version = "0.5.2"
+version = "0.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.ahash]]
@@ -350,15 +350,11 @@ version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.chacha20]]
-version = "0.9.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.chacha20]]
 version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.chacha20poly1305]]
-version = "0.10.1"
+version = "0.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.chrono]]
@@ -378,7 +374,7 @@ version = "0.2.2"
 criteria = "safe-to-run"
 
 [[exemptions.cipher]]
-version = "0.4.4"
+version = "0.5.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap]]
@@ -990,7 +986,7 @@ version = "0.1.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.inout]]
-version = "0.1.4"
+version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.ipnet]]
@@ -1281,10 +1277,6 @@ criteria = "safe-to-deploy"
 version = "11.1.5"
 criteria = "safe-to-run"
 
-[[exemptions.opaque-debug]]
-version = "0.3.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.openssl-probe]]
 version = "0.2.1"
 criteria = "safe-to-deploy"
@@ -1422,7 +1414,7 @@ version = "0.18.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.poly1305]]
-version = "0.8.0"
+version = "0.9.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.portable-atomic]]
@@ -2142,7 +2134,7 @@ version = "0.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.universal-hash]]
-version = "0.5.1"
+version = "0.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.unsafe-libyaml]]

--- a/vellaveto-mcp-shield/Cargo.toml
+++ b/vellaveto-mcp-shield/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 vellaveto-types = { path = "../vellaveto-types", version = "6.0.9" }
 vellaveto-audit = { path = "../vellaveto-audit", version = "6.0.9" }
 vellaveto-config = { path = "../vellaveto-config", version = "6.0.9" }
-chacha20poly1305 = "0.10"
+chacha20poly1305 = "0.11"
 argon2 = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }

--- a/vellaveto-mcp-shield/src/crypto.rs
+++ b/vellaveto-mcp-shield/src/crypto.rs
@@ -133,10 +133,10 @@ impl EncryptedAuditStore {
         let cipher = XChaCha20Poly1305::new((&self.key).into());
         let mut nonce_bytes = [0u8; NONCE_LEN];
         rand::rng().fill_bytes(&mut nonce_bytes);
-        let nonce = XNonce::from_slice(&nonce_bytes);
+        let nonce = XNonce::from(nonce_bytes);
 
         let ciphertext = cipher
-            .encrypt(nonce, plaintext)
+            .encrypt(&nonce, plaintext)
             .map_err(|e| ShieldError::Encryption(format!("encrypt: {e}")))?;
 
         // nonce || ciphertext (includes tag)
@@ -154,11 +154,14 @@ impl EncryptedAuditStore {
             ));
         }
         let cipher = XChaCha20Poly1305::new((&self.key).into());
-        let nonce = XNonce::from_slice(&data[..NONCE_LEN]);
+        let nonce_bytes: [u8; NONCE_LEN] = data[..NONCE_LEN]
+            .try_into()
+            .map_err(|_| ShieldError::Decryption("invalid nonce length".to_string()))?;
+        let nonce = XNonce::from(nonce_bytes);
         let ciphertext = &data[NONCE_LEN..];
 
         cipher
-            .decrypt(nonce, ciphertext)
+            .decrypt(&nonce, ciphertext)
             .map_err(|e| ShieldError::Decryption(format!("decrypt: {e}")))
     }
 

--- a/vellaveto-mcp-shield/src/tests.rs
+++ b/vellaveto-mcp-shield/src/tests.rs
@@ -261,6 +261,56 @@ fn test_session_history_bounded() {
 // Crypto Tests
 // ═══════════════════════════════════════════════════════════════════
 
+/// Known-answer test pinning the XChaCha20-Poly1305 ciphertext format.
+///
+/// The encrypted audit store persists data to disk, so a change in the AEAD
+/// output would silently render existing stores undecryptable. A round-trip
+/// test cannot catch that: it would encrypt and decrypt with the same new
+/// implementation and pass regardless.
+///
+/// This vector was generated under chacha20poly1305 0.10.1 and must continue
+/// to hold across dependency upgrades. If it ever fails, existing on-disk
+/// audit stores are no longer readable and the change is not backward
+/// compatible.
+#[test]
+fn test_crypto_xchacha20poly1305_known_answer_vector() {
+    use chacha20poly1305::{
+        aead::{Aead, KeyInit},
+        XChaCha20Poly1305, XNonce,
+    };
+
+    let key = [0x42u8; 32];
+    let nonce_bytes = [0x24u8; 24];
+    let plaintext = b"vellaveto shield audit record v1";
+
+    // Generated with chacha20poly1305 0.10.1.
+    let expected_hex = "d33bbb090f5229d2cd0f4c5267ed61ae1290fbde156b54ef\
+                        4402893f0f30adfccd28009ca082e31886a2c3fb67c280c1";
+
+    let cipher = XChaCha20Poly1305::new((&key).into());
+    let nonce = XNonce::from(nonce_bytes);
+
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext.as_ref())
+        .expect("encryption must succeed");
+
+    let actual_hex: String = ciphertext.iter().map(|b| format!("{b:02x}")).collect();
+    assert_eq!(
+        actual_hex, expected_hex,
+        "XChaCha20-Poly1305 ciphertext changed — existing encrypted audit \
+         stores would no longer decrypt"
+    );
+
+    // 32-byte plaintext plus the 16-byte Poly1305 tag.
+    assert_eq!(ciphertext.len(), 48, "unexpected tag length");
+
+    // The stored form must decrypt back to the original plaintext.
+    let recovered = cipher
+        .decrypt(&nonce, ciphertext.as_ref())
+        .expect("decryption of the pinned vector must succeed");
+    assert_eq!(recovered, plaintext);
+}
+
 #[test]
 fn test_crypto_encrypt_decrypt_roundtrip() {
     let dir = tempfile::tempdir().unwrap();

--- a/vellaveto-mcp/Cargo.toml
+++ b/vellaveto-mcp/Cargo.toml
@@ -53,7 +53,7 @@ percent-encoding = { workspace = true }
 idna = "1.0"
 ed25519-dalek = { workspace = true }
 subtle = "2"
-chacha20poly1305 = "0.10"
+chacha20poly1305 = "0.11"
 rand = { workspace = true }
 rand_core_06 = { workspace = true }
 getrandom = "0.4"

--- a/vellaveto-mcp/src/task_security.rs
+++ b/vellaveto-mcp/src/task_security.rs
@@ -615,9 +615,10 @@ impl SecureTaskManager {
             ));
         }
 
-        let nonce_arr: [u8; 12] = nonce_bytes.as_slice().try_into().map_err(|_| {
-            TaskSecurityError::DecryptionFailed("Invalid nonce length".to_string())
-        })?;
+        let nonce_arr: [u8; 12] = nonce_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| TaskSecurityError::DecryptionFailed("Invalid nonce length".to_string()))?;
         let nonce = Nonce::from(nonce_arr);
 
         let plaintext = self

--- a/vellaveto-mcp/src/task_security.rs
+++ b/vellaveto-mcp/src/task_security.rs
@@ -586,11 +586,11 @@ impl SecureTaskManager {
         let mut nonce_bytes = [0u8; 12];
         getrandom::fill(&mut nonce_bytes)
             .map_err(|e| TaskSecurityError::EncryptionFailed(e.to_string()))?;
-        let nonce = Nonce::from_slice(&nonce_bytes);
+        let nonce = Nonce::from(nonce_bytes);
 
         let ciphertext = self
             .cipher
-            .encrypt(nonce, plaintext.as_ref())
+            .encrypt(&nonce, plaintext.as_ref())
             .map_err(|e| TaskSecurityError::EncryptionFailed(e.to_string()))?;
 
         Ok((BASE64.encode(&ciphertext), BASE64.encode(nonce_bytes)))
@@ -615,11 +615,14 @@ impl SecureTaskManager {
             ));
         }
 
-        let nonce = Nonce::from_slice(&nonce_bytes);
+        let nonce_arr: [u8; 12] = nonce_bytes.as_slice().try_into().map_err(|_| {
+            TaskSecurityError::DecryptionFailed("Invalid nonce length".to_string())
+        })?;
+        let nonce = Nonce::from(nonce_arr);
 
         let plaintext = self
             .cipher
-            .decrypt(nonce, ciphertext.as_ref())
+            .decrypt(&nonce, ciphertext.as_ref())
             .map_err(|e| TaskSecurityError::DecryptionFailed(e.to_string()))?;
 
         serde_json::from_slice(&plaintext)


### PR DESCRIPTION
Third of the crypto major bumps bundled into #306. This one encrypts **data at rest** — the shield's encrypted audit store and credential vault — so ciphertext compatibility is what actually matters.

### Adds a known-answer test pinning the AEAD output

A round-trip test **cannot** detect an AEAD format change: it encrypts and decrypts with the same new implementation and passes either way. The new test fixes key, nonce and plaintext and asserts the exact ciphertext bytes, so a change that would orphan existing on-disk stores fails loudly.

| | |
|---|---|
| key | `[0x42; 32]` |
| nonce | `[0x24; 24]` |
| plaintext | `"vellaveto shield audit record v1"` |
| ciphertext | `d33bbb09..67c280c1` — 48 bytes (32 plaintext + 16 Poly1305 tag) |

**The vector was generated under 0.10.1 and verified byte-identical under 0.11.0.** Existing encrypted audit stores remain decryptable. The test is permanent, so future AEAD bumps inherit the same guard.

### The dependency change

`aead` 0.5 → 0.6 brings `hybrid_array` and deprecates `Nonce::from_slice`. With `RUSTFLAGS=-Dwarnings` that is a hard failure, so five call sites move off it:

- `vellaveto-mcp-shield/src/crypto.rs` — encrypt, decrypt
- `vellaveto-mcp/src/task_security.rs` — encrypt, decrypt
- `vellaveto-mcp-shield/src/tests.rs` — the new known-answer test

Fixed-size arrays become `Nonce::from(bytes)`. The two **slice-sourced** sites are library code where `unwrap()` is banned, so they convert fallibly and map onto the existing error types rather than panicking on malformed input:

```rust
ShieldError::Decryption("invalid nonce length")
TaskSecurityError::DecryptionFailed("Invalid nonce length")
```

Transitively: `chacha20` and `opaque-debug` drop out; `cipher`, `inout`, `poly1305`, `universal-hash` move up. Duplicate baseline unchanged at 28 names.

### Verification

| gate | result |
|---|---|
| `cargo check --workspace --all-targets --locked` | 0 errors |
| `cargo clippy` (CI-exact flags) | 0 warnings |
| **known-answer vector under 0.11** | **byte-identical to 0.10** |
| `scripts/check-cargo-duplicates.sh` | OK, 28 names |
| `cargo vet --locked` | Vetting Succeeded (626 exempted) |
| `cargo deny check` | advisories / bans / licenses / sources ok |
| CI unwrap scanner | no new library `unwrap`/`expect` |
| full suite + 6 feature combos | **still running locally when pushed — CI is the gate** |

cargo-vet exemptions regenerated in the same commit.