### PR TITLE
deps(crypto): migrate p256 0.13 -> 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -969,6 +969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,12 +1093,16 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -1114,7 +1124,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1124,6 +1136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -1276,7 +1289,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1390,16 +1414,17 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
- "der",
- "digest 0.10.7",
+ "der 0.8.1",
+ "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1408,8 +1433,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1450,19 +1475,20 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
  "ff",
- "generic-array",
  "group",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
  "sec1",
  "subtle",
  "zeroize",
@@ -1569,11 +1595,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1809,7 +1835,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1913,12 +1938,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2128,7 +2153,9 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -2611,7 +2638,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "signature",
+ "signature 2.2.0",
  "simple_asn1",
  "zeroize",
 ]
@@ -3298,14 +3325,15 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3379,6 +3407,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -3475,9 +3512,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3486,8 +3523,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3604,12 +3651,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -4141,12 +4206,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
- "hmac 0.12.1",
- "subtle",
+ "crypto-bigint",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -4195,10 +4260,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -4426,14 +4491,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
- "der",
- "generic-array",
- "pkcs8",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -4616,6 +4681,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4697,6 +4772,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4789,7 +4874,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -6701,6 +6796,17 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
+]
 
 [[package]]
 name = "writeable"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -262,7 +262,7 @@ version = "1.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.base16ct]]
-version = "0.2.0"
+version = "1.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.base64]]
@@ -437,6 +437,10 @@ criteria = "safe-to-deploy"
 version = "0.8.7"
 criteria = "safe-to-deploy"
 
+[[exemptions.cpubits]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.cpufeatures]]
 version = "0.2.17"
 criteria = "safe-to-deploy"
@@ -486,7 +490,7 @@ version = "0.2.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.crypto-bigint]]
-version = "0.5.5"
+version = "0.7.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.crypto-common]]
@@ -557,6 +561,10 @@ criteria = "safe-to-deploy"
 version = "0.7.10"
 criteria = "safe-to-deploy"
 
+[[exemptions.der]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.der-parser]]
 version = "10.0.0"
 criteria = "safe-to-deploy"
@@ -602,7 +610,7 @@ version = "1.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.ecdsa]]
-version = "0.16.9"
+version = "0.17.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ed25519]]
@@ -622,7 +630,7 @@ version = "1.17.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.elliptic-curve]]
-version = "0.13.8"
+version = "0.14.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.enum-ordinalize]]
@@ -670,7 +678,7 @@ version = "0.3.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.ff]]
-version = "0.13.1"
+version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.fiat-crypto]]
@@ -806,7 +814,7 @@ version = "0.10.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.group]]
-version = "0.13.0"
+version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.h2]]
@@ -1318,7 +1326,7 @@ version = "2.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.p256]]
-version = "0.13.2"
+version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.page_size]]
@@ -1351,6 +1359,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.pem-rfc7468]]
 version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.pem-rfc7468]]
+version = "1.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.percent-encoding]]
@@ -1395,6 +1407,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.pkcs8]]
 version = "0.10.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pkcs8]]
+version = "0.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pkg-config]]
@@ -1449,8 +1465,12 @@ criteria = "safe-to-deploy"
 version = "0.2.37"
 criteria = "safe-to-deploy"
 
+[[exemptions.primefield]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.primeorder]]
-version = "0.13.6"
+version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.proc-macro2]]
@@ -1626,7 +1646,7 @@ version = "0.13.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.rfc6979]]
-version = "0.4.0"
+version = "0.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ring]]
@@ -1734,7 +1754,7 @@ version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.sec1]]
-version = "0.7.3"
+version = "0.8.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.secrecy]]
@@ -1801,6 +1821,10 @@ criteria = "safe-to-deploy"
 version = "0.9.34+deprecated"
 criteria = "safe-to-deploy"
 
+[[exemptions.serdect]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.sha1]]
 version = "0.10.7"
 criteria = "safe-to-deploy"
@@ -1835,6 +1859,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.signature]]
 version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.signature]]
+version = "3.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.simd-adler32]]
@@ -1879,6 +1907,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.spki]]
 version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.spki]]
+version = "0.8.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.sqlx]]
@@ -2503,6 +2535,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.wit-bindgen]]
 version = "0.57.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wnaf]]
+version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.writeable]]

--- a/vellaveto-mcp/Cargo.toml
+++ b/vellaveto-mcp/Cargo.toml
@@ -75,7 +75,7 @@ image = { version = "0.25", optional = true, default-features = false, features 
 flate2 = { workspace = true }
 
 # FIPS 140-3 compliance mode (Phase 23.3)
-p256 = { version = "0.13", features = ["ecdsa"], optional = true }
+p256 = { version = "0.14", features = ["ecdsa"], optional = true }
 
 # Consumer shield (bidirectional PII sanitization)
 vellaveto-mcp-shield = { path = "../vellaveto-mcp-shield", version = "6.0.9", optional = true }

--- a/vellaveto-mcp/src/fips.rs
+++ b/vellaveto-mcp/src/fips.rs
@@ -192,7 +192,17 @@ impl FipsMode {
 pub fn sign_ecdsa_p256(data: &[u8], private_key: &[u8]) -> Result<Vec<u8>, FipsError> {
     use p256::ecdsa::{signature::Signer, Signature, SigningKey};
 
-    let signing_key = SigningKey::from_bytes(private_key.into())
+    // p256 0.14 removed the `&[u8]` conversion into the field-element array,
+    // so the length is now checked explicitly instead of failing inside
+    // `from_bytes`. A P-256 scalar is always 32 bytes.
+    let key_bytes: &[u8; 32] = private_key.try_into().map_err(|_| {
+        FipsError::InvalidKey(format!(
+            "Invalid P-256 private key: expected 32 bytes, got {}",
+            private_key.len()
+        ))
+    })?;
+
+    let signing_key = SigningKey::from_bytes(key_bytes.into())
         .map_err(|e| FipsError::InvalidKey(format!("Invalid P-256 private key: {}", e)))?;
 
     let signature: Signature = signing_key.sign(data);
@@ -209,11 +219,12 @@ pub fn verify_ecdsa_p256(
     public_key: &[u8],
 ) -> Result<bool, FipsError> {
     use p256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
-    use p256::EncodedPoint;
 
-    let point = EncodedPoint::from_bytes(public_key)
-        .map_err(|e| FipsError::InvalidKey(format!("Invalid P-256 public key: {}", e)))?;
-    let verifying_key = VerifyingKey::from_encoded_point(&point)
+    // p256 0.14 removed `p256::EncodedPoint` from the crate root and dropped
+    // `VerifyingKey::from_encoded_point`. `from_sec1_bytes` parses the same
+    // SEC1 encoding directly, so accepted public-key inputs are unchanged:
+    // both compressed (33-byte) and uncompressed (65-byte) forms still work.
+    let verifying_key = VerifyingKey::from_sec1_bytes(public_key)
         .map_err(|e| FipsError::InvalidKey(format!("Invalid P-256 public key: {}", e)))?;
 
     let sig = Signature::from_der(signature)
@@ -328,6 +339,68 @@ mod tests {
 
         let result = verify_ecdsa_p256(b"test", &[0; 64], &[0; 33]);
         assert!(matches!(result, Err(FipsError::NotEnabled)));
+    }
+
+    /// Round-trip exercise of real P-256 signing and verification.
+    ///
+    /// Only the `NotEnabled` stub path was covered before, so the actual
+    /// cryptography shipped under the `fips` feature had no test at all.
+    #[cfg(feature = "fips")]
+    #[test]
+    fn test_ecdsa_p256_sign_verify_roundtrip() {
+        use p256::ecdsa::SigningKey;
+
+        let private_key = [0x11u8; 32];
+        let data = b"vellaveto fips p256 attestation v1";
+
+        let signature = sign_ecdsa_p256(data, &private_key).expect("signing must succeed");
+
+        let key = SigningKey::from_bytes((&private_key).into()).expect("valid key");
+        let public_point = key.verifying_key().to_sec1_point(false);
+
+        assert!(
+            verify_ecdsa_p256(data, &signature, public_point.as_bytes()).expect("verify must run"),
+            "a signature must verify against its own public key"
+        );
+
+        assert!(
+            !verify_ecdsa_p256(b"tampered", &signature, public_point.as_bytes())
+                .expect("verify must run"),
+            "a signature must not verify against different data"
+        );
+    }
+
+    /// Known-answer test pinning the DER-encoded ECDSA P-256 signature.
+    ///
+    /// ECDSA signatures here are deterministic (RFC 6979), so a fixed key and
+    /// message must always produce identical DER bytes. Signatures are a wire
+    /// format consumed by verifiers outside this process, so a change in the
+    /// encoding would break interoperability without failing a round-trip
+    /// test — which signs and verifies with the same implementation and would
+    /// pass regardless.
+    ///
+    /// This vector was generated under p256 0.13 and must continue to hold
+    /// across dependency upgrades.
+    #[cfg(feature = "fips")]
+    #[test]
+    fn test_ecdsa_p256_known_answer_vector() {
+        let private_key = [0x11u8; 32];
+        let data = b"vellaveto fips p256 attestation v1";
+
+        // Generated with p256 0.13, RFC 6979 deterministic nonce.
+        let expected_hex = "30460221008b4d9c4ffb80a3b85156e756ac5fdd53b33c4c519b57966d\
+                            99a822ec186a15be022100f7f0cbfd98924f9a1c1f3da56f3f81b0681d\
+                            79284f5ab71f63d1dbba7b5f2b6f";
+
+        let signature = sign_ecdsa_p256(data, &private_key).expect("signing must succeed");
+        let actual_hex: String = signature.iter().map(|b| format!("{b:02x}")).collect();
+
+        assert_eq!(
+            actual_hex, expected_hex,
+            "ECDSA P-256 DER signature changed — external verifiers would reject \
+             signatures produced by this build"
+        );
+        assert_eq!(signature.len(), 72, "unexpected DER signature length");
     }
 
     #[test]


### PR DESCRIPTION
Fourth of the crypto major bumps bundled into #306.

### This one is invisible to CI

`p256` is optional behind the `fips` feature, and **no workflow enables it**. The default build compiled with **0 errors** while `--features fips` had **7** — this would have merged completely broken.

| Break in p256 0.14 | Fix |
|---|---|
| `p256::EncodedPoint` removed from crate root | — |
| `VerifyingKey::from_encoded_point` removed | `from_sec1_bytes` — parses the same SEC1 encoding, so compressed (33-byte) and uncompressed (65-byte) public keys both still work |
| `SigningKey::from_bytes(slice.into())` no longer converts from `&[u8]` | explicit 32-byte scalar length check mapped to `FipsError::InvalidKey` rather than panicking; previously the error surfaced from inside `from_bytes` |

### Adds the tests this code never had

Only the `NotEnabled` stub path was covered — the actual signing and verification shipped under `fips` had **no test at all**.

- `test_ecdsa_p256_sign_verify_roundtrip` — signs, verifies, and asserts a tampered message does **not** verify
- `test_ecdsa_p256_known_answer_vector` — pins the DER signature bytes

ECDSA here is deterministic (RFC 6979), so a fixed key and message must always produce identical DER. Signatures are a wire format consumed by verifiers outside this process, so an encoding change would break interoperability **without failing a round-trip test** — which signs and verifies with the same implementation and passes either way.

**The vector was generated under 0.13 and verified byte-identical under 0.14.**

### Note on the duplicate-crate gate

It reads the **default-feature** resolve, where `p256`, `ecdsa` and `elliptic-curve` are absent entirely.

```
default resolve   29 duplicate names
with fips         33 duplicate names   (incl. signature 2.2.0 + 3.0.0)
```

A green baseline does not mean no duplicates exist. The same blind spot hides curve25519-dalek 4/5 coexistence under `zk-audit` in #313.

### Verification

| gate | result |
|---|---|
| `cargo check --workspace --all-targets --locked` | 0 errors |
| `cargo check -p vellaveto-mcp --features fips` | 0 errors |
| `cargo clippy` default and `--features fips` | 0 warnings |
| `cargo fmt --all -- --check` | clean |
| **known-answer DER vector under 0.14** | **byte-identical to 0.13** |
| `scripts/check-cargo-duplicates.sh` | OK, 29 names |
| `cargo vet --locked` | Vetting Succeeded (637 exempted) |
| `cargo deny check` | advisories / bans / licenses / sources ok |
| `cargo test --workspace --no-fail-fast` | **11,650 passed, 0 failed**, 26 ignored |
| feature combos (7, `fips` included) | all OK |

### Expected to fail Semver Check

Like #313 and #315, this touches `vellaveto-*/src/**.rs` and will trip the pre-existing semver gate. That failure is unrelated to this change: published `v6.1.1` dates to 2026-03-27 and main is 273 commits ahead, with public struct fields added since across multiple crates (`EvidencePack` 2026-03-29, `StreamableHttpConfig` 2026-05-31). Reproduced on unmodified main.