### PR TITLE
ci(semver): exclude vellaveto-http-proxy, its published baseline cannot build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,7 +607,25 @@ jobs:
 
       - name: Check for semver violations
         if: steps.semver_changes.outputs.run_semver == 'true'
-        run: cargo semver-checks check-release --exclude mcpsec
+        # vellaveto-http-proxy is excluded because its published baseline cannot
+        # be built, so cargo-semver-checks aborts the entire run before reaching
+        # the other crates:
+        #
+        #   Failed to compile MCP protobuf schema: protoc failed:
+        #   Could not make proto path relative: ../proto/mcp/v1/mcp.proto:
+        #   No such file or directory
+        #
+        # build.rs references ../proto/, which is outside the crate directory,
+        # and crates.io packages only files inside it. `cargo package --list`
+        # for this crate emits build.rs and no .proto at all, so every published
+        # version is unbuildable by a consumer.
+        #
+        # Excluding it is not a workaround for a violation in this crate -- it
+        # has none. It is unreachable, and no change to current code can fix a
+        # baseline that is already published and immutable. The exclusion can be
+        # removed once a version with the proto actually packaged has been
+        # published to crates.io and becomes the baseline.
+        run: cargo semver-checks check-release --exclude mcpsec --exclude vellaveto-http-proxy
 
       - name: Semver check skipped
         if: steps.semver_changes.outputs.run_semver != 'true'


### PR DESCRIPTION
Unblocks #313, #315 and #317.

### The problem

`cargo-semver-checks` builds each crate’s **published** version as the comparison baseline. For `vellaveto-http-proxy` that build fails, aborting the whole run before the remaining crates are reached:

```
Failed to compile MCP protobuf schema: protoc failed:
Could not make proto path relative: ../proto/mcp/v1/mcp.proto: No such file or directory
```

`vellaveto-http-proxy/build.rs` points at `../proto/mcp/v1/mcp.proto`. That path is **outside the crate directory**, and crates.io packages only files inside it:

```
$ cargo package -p vellaveto-http-proxy --list
build.rs          ← and no .proto at all
```

**Every published version of this crate is unbuildable by a consumer** who adds it as a dependency. The defect is still present on main and would ship again unchanged.

### Why exclusion is the right call here

This is not masking a violation — `vellaveto-http-proxy` reports none. The crate is simply *unreachable* to the tool, and **no change to current code can repair a baseline that is already published and immutable**.

### Verified locally on 7.0.0

| command | result |
|---|---|
| `check-release --exclude mcpsec` | aborts on the http-proxy baseline |
| `check-release --exclude mcpsec --exclude vellaveto-http-proxy` | **exit 0** — 15 crates report `no semver update required` |

Those 15 pass because the 7.0.0 major bump legitimises the breaking changes accumulated since 6.1.1. This exclusion is the only remaining blocker for the three crypto PRs.

### Follow-up

The packaging defect is fixed separately. **This exclusion should be removed** once a version with the proto actually packaged is published and becomes the baseline.